### PR TITLE
Add user function to be executed when a PHT alarm is set off.

### DIFF
--- a/Software/examples/Example16_GlobalTracker/Tracker_Message_Fields.h
+++ b/Software/examples/Example16_GlobalTracker/Tracker_Message_Fields.h
@@ -236,6 +236,15 @@
 #define MOFIELDS2_LOWBATT   0x00200000
 #define MOFIELDS2_DYNMODEL  0x00100000
 
+// Define the bits for the alarm types
+#define ALARM_HIPRESS 0x01
+#define ALARM_LOPRESS 0x02
+#define ALARM_HITEMP  0x04
+#define ALARM_LOTEMP  0x08
+#define ALARM_HIHUMID 0x10
+#define ALARM_LOHUMID 0x20
+#define ALARM_LOBATT  0x40
+
 #define MOLIM 340 // Length limit for a Mobile Originated message
 #define MTLIM 270 // Length limit for a Mobile Terminated message
 

--- a/Software/examples/Example16_GlobalTracker/Tracker_User_Functions.ino
+++ b/Software/examples/Example16_GlobalTracker/Tracker_User_Functions.ino
@@ -112,3 +112,9 @@ float USER_VAL_8()
   retVal = 8.0E8; // Set retVal to 8.0E8 for testing - delete this line if you add your own code
   return (retVal);
 }
+
+void ALARM_FUNC(uint8_t alarmType)
+{
+  debugPrintln(F("Executing ALARM_FUNC ..."));
+  // Add your own code to be executed when an alarm is set off.
+}


### PR DESCRIPTION
I have added a user function that is executed when a PHT alarm is set off. This user function is intentionally executed always when the thresholds are exceeded, not only when the alarm is active, because this gives the user more flexibility, as the condition whether the alarm is activated can be checked in the user function or not. This feature is useful, e.g., to trigger hardware connected to the ATG upon alarms.